### PR TITLE
fix remote_address

### DIFF
--- a/clearml_session/__main__.py
+++ b/clearml_session/__main__.py
@@ -768,7 +768,6 @@ def monitor_ssh_tunnel(state, task):
                 remote_address = task_parameters.get('properties/k8s-gateway-address')
                 if bool(state.get('public_ip')):
                     remote_address = task_parameters.get('properties/external_address')
-                print(f"remote_address: {remote_address}")
                     
                 internal_ssh_port = task_parameters.get('properties/internal_ssh_port')
                 jupyter_port = task_parameters.get('properties/jupyter_port')

--- a/clearml_session/__main__.py
+++ b/clearml_session/__main__.py
@@ -765,9 +765,11 @@ def monitor_ssh_tunnel(state, task):
                     ssh_password = task_parameters.get('{}/ssh_password'.format(section)) or state.get('password', '')
                     jupyter_token = task_parameters.get('properties/jupyter_token')
 
-                remote_address = \
-                    task_parameters.get('properties/k8s-gateway-address') or \
-                    task_parameters.get('properties/external_address')
+                remote_address = task_parameters.get('properties/k8s-gateway-address')
+                if bool(state.get('public_ip')):
+                    remote_address = task_parameters.get('properties/external_address')
+                print(f"remote_address: {remote_address}")
+                    
                 internal_ssh_port = task_parameters.get('properties/internal_ssh_port')
                 jupyter_port = task_parameters.get('properties/jupyter_port')
                 ssh_port = \

--- a/clearml_session/interactive_session_task.py
+++ b/clearml_session/interactive_session_task.py
@@ -827,6 +827,7 @@ def get_host_name(task, param):
                 external_addr = requests.get('https://checkip.amazonaws.com').text.strip()
             except Exception:
                 pass
+            task.set_parameter(name='properties/k8s-gateway-address', value=str(external_addr))
         task.set_parameter(name='properties/external_address', value=str(external_addr))
 
     return hostname, hostnames


### PR DESCRIPTION
k8s-gateway-address is fixed when clearml-agent is installed.
but if i run with argument '--public-ip', nothing happends even thought it set in external_address parameter. and clearml-session occurs an error: ssh tunneling failed

i want to use public ip as an remote address:)