### PR TITLE
bugfix: handle ssh key login

### DIFF
--- a/clearml_session/__main__.py
+++ b/clearml_session/__main__.py
@@ -669,7 +669,7 @@ def wait_for_machine(state, task):
 def start_ssh_tunnel(username, remote_address, ssh_port, ssh_password, local_remote_pair_list, debug=False):
     print('Starting SSH tunnel')
     child = None
-    args = ['-N', '-C',
+    args = ['-C',
             '{}@{}'.format(username, remote_address), '-p', '{}'.format(ssh_port),
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'Compression=yes',

--- a/clearml_session/__main__.py
+++ b/clearml_session/__main__.py
@@ -669,7 +669,7 @@ def wait_for_machine(state, task):
 def start_ssh_tunnel(username, remote_address, ssh_port, ssh_password, local_remote_pair_list, debug=False):
     print('Starting SSH tunnel')
     child = None
-    args = ['-N', '-C',
+    args = ['-C',
             '{}@{}'.format(username, remote_address), '-p', '{}'.format(ssh_port),
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'Compression=yes',
@@ -690,7 +690,7 @@ def start_ssh_tunnel(username, remote_address, ssh_port, ssh_password, local_rem
             args=args,
             logfile=fd, timeout=20, encoding='utf-8')
 
-        i = child.expect([r'(?i)password:', r'\(yes\/no\)', r'.*[$#] ', pexpect.EOF])
+        i = child.expect([r'(?i)password:', r'\(yes\/no', r'.*[$#] ', pexpect.EOF])
         if i == 0:
             child.sendline(ssh_password)
             try:

--- a/clearml_session/__main__.py
+++ b/clearml_session/__main__.py
@@ -669,7 +669,7 @@ def wait_for_machine(state, task):
 def start_ssh_tunnel(username, remote_address, ssh_port, ssh_password, local_remote_pair_list, debug=False):
     print('Starting SSH tunnel')
     child = None
-    args = ['-C',
+    args = ['-N', '-C',
             '{}@{}'.format(username, remote_address), '-p', '{}'.format(ssh_port),
             '-o', 'UserKnownHostsFile=/dev/null',
             '-o', 'Compression=yes',
@@ -690,6 +690,7 @@ def start_ssh_tunnel(username, remote_address, ssh_port, ssh_password, local_rem
             args=args,
             logfile=fd, timeout=20, encoding='utf-8')
 
+        # Match only "(yes/no" in order to handle both (yes/no) and (yes/no/[fingerprint])
         i = child.expect([r'(?i)password:', r'\(yes\/no', r'.*[$#] ', pexpect.EOF])
         if i == 0:
             child.sendline(ssh_password)


### PR DESCRIPTION
This code https://github.com/allegroai/clearml-session/blob/main/clearml_session/__main__.py#LL693C61-L693C72 checks for the beginning of a shell, but the `-N` [here](https://github.com/allegroai/clearml-session/blob/main/clearml_session/__main__.py#LL672C13-L672C17) causes ssh to never open an interactive session. Additionally, [this code](https://github.com/allegroai/clearml-session/blob/main/clearml_session/__main__.py#LL693C45-L693C59) checks for `(yes/no)` when prompted to verify the node fingerprint, but now these messages can appear as `(yes/no/[fingerprint])` (see https://github.com/openbsd/src/commit/6be7898a800bb957b24bae65585ad28285868b14).

This PR removes the `-N` argument to ssh so that a key-based login will see a shell prompt and allow the `child.expects` call to function as intended. It also fixes the `(yes/no)` check so that it can handle a possible `(yes/no/[fingerprint])` printout.